### PR TITLE
Made native examples include kotest itself, if it exists in a sibling…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ local.properties
 *.gpg.enc
 
 kotest-tests/kotest-tests-js/node_modules/
+.DS_Store

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.mpp.stability.nowarn=true
+org.gradle.jvmargs=-Xmx3G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,4 @@
+if (File("../kotest").exists() && System.getenv("NO_INCLUDE") == null) {
+   println("w: Including Kotest build, will substitute all Kotest stuff for currently checked out implementations")
+   includeBuild("../kotest")
+}


### PR DESCRIPTION
… directory

With this, we can make a code change in `kotest` and directly try it out without first having to publish the right stuff to `mavenLocal`, gradle will resolve it from the included build 🪄  